### PR TITLE
feat: Google/네이버 Search Console HTML 인증 파일 추가

### DIFF
--- a/frontend/public/google22b0649ec86a471a.html
+++ b/frontend/public/google22b0649ec86a471a.html
@@ -1,0 +1,1 @@
+google-site-verification: google22b0649ec86a471a.html

--- a/frontend/public/naver986f04c1a896a8ce969f425104062ae1.html
+++ b/frontend/public/naver986f04c1a896a8ce969f425104062ae1.html
@@ -1,0 +1,1 @@
+naver-site-verification: naver986f04c1a896a8ce969f425104062ae1.html

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -83,12 +83,6 @@ export default function RootLayout({
         <meta name="application-name" content="(주)정석기술연구소" />
         <meta name="msapplication-TileColor" content="#2b5797" />
         <meta name="theme-color" content="#ffffff" />
-
-        <meta
-          name="naver-site-verification"
-          content="87f8d9d318bd413e98fb8045f87e63b644cdeffb"
-        />
-
         <script
           type="application/ld+json"
           dangerouslySetInnerHTML={{


### PR DESCRIPTION
## Summary
- Google Search Console HTML 인증 파일 추가 (`google22b0649ec86a471a.html`)
- 네이버 Search Advisor HTML 인증 파일 추가 (`naver986f04c1a896a8ce969f425104062ae1.html`)
- 기존 네이버 메타태그 인증 방식 제거 (HTML 파일 인증으로 전환)

## Test plan
- [ ] 배포 후 `https://jseng.fly.dev/google22b0649ec86a471a.html` 접근 확인
- [ ] 배포 후 `https://jseng.fly.dev/naver986f04c1a896a8ce969f425104062ae1.html` 접근 확인
- [ ] Google Search Console에서 소유권 인증 완료
- [ ] 네이버 Search Advisor에서 소유권 인증 완료

🤖 Generated with [Claude Code](https://claude.com/claude-code)