### PR TITLE
fix: 구글 seo 인증

### DIFF
--- a/frontend/public/google22b0649ec86a471a.html
+++ b/frontend/public/google22b0649ec86a471a.html
@@ -1,1 +1,0 @@
-google-site-verification: google22b0649ec86a471a.html

--- a/frontend/public/google2cd6f608d84c8e39.html
+++ b/frontend/public/google2cd6f608d84c8e39.html
@@ -1,1 +1,0 @@
-google-site-verification: google2cd6f608d84c8e39.html

--- a/frontend/public/google3ca89f289d74fd5c.html
+++ b/frontend/public/google3ca89f289d74fd5c.html
@@ -1,0 +1,1 @@
+google-site-verification: google3ca89f289d74fd5c.html


### PR DESCRIPTION
## Summary
- Google Search Console HTML 인증 파일 교체 (`google2cd6f608d84c8e39.html` → `google3ca89f289d74fd5c.html`)
- 네이버 Search Advisor HTML 인증 파일 추가 (`naver986f04c1a896a8ce969f425104062ae1.html`)
- 네이버 메타태그 인증 방식을 HTML 파일 인증 방식으로 전환 (기존 메타태그 제거)

## Test plan
- [ ] 배포 후 `https://jseng.fly.dev/google3ca89f289d74fd5c.html` 접근 확인
- [ ] 배포 후 `https://jseng.fly.dev/naver986f04c1a896a8ce969f425104062ae1.html` 접근 확인
- [ ] Google Search Console에서 소유권 인증 완료
- [ ] 네이버 Search Advisor에서 소유권 인증 완료